### PR TITLE
Plaintext auth

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -12,6 +12,7 @@ $ npm install co-ssh
 ## Example
 
 ```js
+var co = require('co');
 var ssh = require('co-ssh');
 
 ...
@@ -21,10 +22,14 @@ var c = ssh({
   key: read(process.env.HOME + '/.ssh/some.pem')
 });
 
-yield c.connect();
-yield c.exec('foo');
-yield c.exec('bar');
-yield c.exec('baz');
+co(function *() {
+  yield c.connect();
+  
+  console.log(yield c.exec('pwd'));
+  
+  var ls = yield c.exec('ls -l');
+  console.log(ls);
+});
 ...
 ```
 

--- a/Readme.md
+++ b/Readme.md
@@ -33,6 +33,20 @@ co(function *() {
 ...
 ```
 
+### Example using plain-text authentication
+Simply replace `key` option with `password`
+
+```js
+...
+var c = ssh({
+  host: 'n.n.n.n',
+  user: 'myuser',
+  password: 'mypass'
+});
+...
+
+```
+
 # License
 
   MIT

--- a/index.js
+++ b/index.js
@@ -30,9 +30,10 @@ function Connection(opts) {
  * Connect with `opts`.
  *
  * - `host`
- * - `port`
+ * - `port` defaults to 22
  * - `user`
- * - `key`
+ * - `key` for private-key or `password` for plain-text
+ * - `encoding` defaults to 'ascii' (a bit faster than 'utf8' if you sure you don't need to handle fancy chars)
  *
  * @param {Object} opts
  * @return {Function}
@@ -45,19 +46,30 @@ Connection.prototype.connect = function(opts){
 
   // default port
   opts.port = opts.port || 22;
+  
+  // default encoding
+  this.encoding = opts.encoding || 'ascii'
 
   // required
   assert(opts.host, '.host required');
   assert(opts.user, '.user required');
-  assert(opts.key, '.key required');
-  opts.privateKey = opts.key;
+  assert(opts.key || opts.password, '.key or .password required');
+  
   opts.username = opts.user;
-
-  return function(done){
-    ssh.connect(opts);
-    ssh.once('ready', done);
-    ssh.once('error', done);
+  
+  if (opts.key) {
+    opts.privateKey = opts.key;
   }
+  else if (opts.password) {
+    opts.tryKeyboard = true;
+  }
+
+  return new Promise(function(resolve, reject) {
+    ssh.connect(opts);
+    ssh.once('keyboard-interactive', function() { arguments[4]([opts.password]) });
+    ssh.once('ready', resolve);
+    ssh.once('error', reject);
+  });
 };
 
 /**
@@ -70,15 +82,17 @@ Connection.prototype.connect = function(opts){
 
 Connection.prototype.exec = function(cmd){
   var ssh = this.ssh;
-  return function(done){
+
+  return new Promise(function(resolve, reject) {
     ssh.exec(cmd, function(err, stream){
-      if (err) return done(err);
-      var buf = '';
-      stream.setEncoding('utf8');
-      stream.on('data', function(c){ buf += c });
-      stream.on('end', function(){ done(null, buf) });
+      if (err) return reject(err);
+      
+      var buf = [];
+      stream.setEncoding(this.encoding);
+      stream.on('data', function(c){ buf.push(c) });
+      stream.on('end', function(){ resolve(buf.join('')) });
     });
-  }
+  });
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
     "generators"
   ],
   "dependencies": {
-    "ssh2": "~0.2.14"
+    "ssh2": "~0.4.12"
   },
   "devDependencies": {
     "mocha": "*",
     "should": "*",
-    "co": "~3.0.0"
+    "co": "~4.6.0"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
Major changes:
- added `password` option for plain-text authentication, with somewhat proper handling of `keyboard-interactive` event
- refactor from callback-style to native Promise, in conformance to `co@4+`
- added `encoding` option, defaults to `ascii`, which is a bit faster than `utf8` if we don't expects fancy characters
- refactor from string concatenation to array join when buffering result from `exec`
